### PR TITLE
add detector support for safari

### DIFF
--- a/detect.js
+++ b/detect.js
@@ -41,7 +41,7 @@ module.exports = function(target, prefixes) {
       target.charAt(0).toUpperCase() + target.slice(1) :
       target);
 
-    if (typeof scope[testName] == 'function') {
+    if (scope[testName]) {
       return scope[testName];
     }
   }


### PR DESCRIPTION
I just add detector to support safari because safari returns window.URL as object not function in chrome. I and pete don't know how to run your test. Please do a test run. Thanks.